### PR TITLE
feat: add remote mcp connector support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "highlight.js": "^11.11.1",
     "katex": "^0.16.22",
     "lru-cache": "^11.1.0",
+    "mcp": "^1.5.0",
     "lucide-react": "^0.469.0",
     "microsoft-cognitiveservices-speech-sdk": "^1.44.1",
     "next": "^15.3.3",

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { mcpManager } from '@/utils/mcpConnector';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { name, url, apiKey } = await req.json();
+    if (!name || !url) {
+      return NextResponse.json({ error: 'name and url required' }, { status: 400 });
+    }
+    await mcpManager.registerConnector({ name, url, apiKey });
+    return NextResponse.json({ success: true });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message || 'connector error' }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  return NextResponse.json({ services: mcpManager.listServices() });
+}

--- a/src/app/api/tools/route.ts
+++ b/src/app/api/tools/route.ts
@@ -1,7 +1,7 @@
 // src/app/api/tools/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import { ToolCall, ToolResult, PageContext } from '@/types';
-import { ToolExecutor } from '@/utils/toolManager';
+import { ToolExecutor, getToolDefinitions } from '@/utils/toolManager';
 
 export async function POST(request: NextRequest) {
   try {
@@ -326,7 +326,7 @@ export async function GET() {
   return NextResponse.json({ 
     status: 'ok', 
     service: 'Tools API',
-    supportedTools: ['get_weather','web_search','openmanus_web_automation','openmanus_code_execution','openmanus_file_operations','openmanus_general_task'],
+    supportedTools: getToolDefinitions().map(t => t.function.name),
     timestamp: new Date().toISOString() 
   });
 }

--- a/src/components/FloatingAssistant.tsx
+++ b/src/components/FloatingAssistant.tsx
@@ -19,7 +19,6 @@ interface SearchResult {
 
 // 已移动到统一类型定义中
 import { StreamingSpeechRecognition } from '@/utils/streamingSpeechRecognition';
-import { toolDefinitions } from '@/utils/toolManager';
 import { VoiceCallMode } from './VoiceCall/VoiceCallMode';
 import { VoiceCallManager } from '@/utils/voiceCallManager';
 import UnifiedMessage from './UnifiedMessage';

--- a/src/types/mcp.d.ts
+++ b/src/types/mcp.d.ts
@@ -1,0 +1,1 @@
+declare module 'mcp';

--- a/src/utils/mcpConnector.ts
+++ b/src/utils/mcpConnector.ts
@@ -1,0 +1,110 @@
+import { Client, WebSocketClientTransport } from 'mcp';
+
+export interface MCPConnectorConfig {
+  name: string;
+  url: string;
+  apiKey?: string;
+}
+
+/**
+ * Connector for a single remote MCP service. Handles connection lifecycle
+ * and exposes tool discovery and invocation helpers.
+ */
+export class MCPConnector {
+  private client: any;
+  private tools: any[] = [];
+  private connected = false;
+  private connecting: Promise<void> | null = null;
+
+  constructor(private config: MCPConnectorConfig) {}
+
+  async connect() {
+    await this.ensureConnection();
+  }
+
+  private async ensureConnection() {
+    if (this.connected) return;
+    if (this.connecting) return this.connecting;
+
+    this.connecting = (async () => {
+      const transport = new WebSocketClientTransport(this.config.url, {
+        headers: this.config.apiKey ? { Authorization: `Bearer ${this.config.apiKey}` } : {},
+      });
+      this.client = new Client(transport);
+      await this.client.connect();
+      // some versions of the library expose start(), others handshake()
+      if (typeof this.client.start === 'function') {
+        await this.client.start();
+      } else if (typeof this.client.handshake === 'function') {
+        await this.client.handshake();
+      }
+      const list = await this.client.listTools();
+      this.tools = Array.isArray(list) ? list : list.tools || [];
+      this.connected = true;
+    })();
+
+    return this.connecting;
+  }
+
+  async callTool(name: string, args: any): Promise<any> {
+    try {
+      await this.ensureConnection();
+      return await this.client.callTool(name, args);
+    } catch (err) {
+      this.connected = false; // force reconnect next time
+      throw err;
+    }
+  }
+
+  listTools() {
+    return this.tools.map((t: any) => ({
+      type: 'function',
+      function: {
+        name: t.name,
+        description: t.description || '',
+        parameters: t.inputSchema || { type: 'object', properties: {} },
+      },
+    }));
+  }
+}
+
+class MCPManager {
+  private connectors = new Map<string, MCPConnector>();
+  private toolToConnector = new Map<string, MCPConnector>();
+
+  async registerConnector(config: MCPConnectorConfig) {
+    const connector = new MCPConnector(config);
+    await connector.connect(); // load tools and cache tools list
+    this.connectors.set(config.name, connector);
+    connector.listTools().forEach((tool: any) => {
+      this.toolToConnector.set(tool.function.name, connector);
+    });
+  }
+
+  listTools() {
+    const tools: any[] = [];
+    for (const connector of this.connectors.values()) {
+      tools.push(...connector.listTools());
+    }
+    return tools;
+  }
+
+  listServices() {
+    return Array.from(this.connectors.entries()).map(([name, connector]) => ({
+      name,
+      tools: connector.listTools().map(t => t.function.name),
+    }));
+  }
+
+  hasTool(name: string) {
+    return this.toolToConnector.has(name);
+  }
+
+  async callTool(name: string, args: any) {
+    const connector = this.toolToConnector.get(name);
+    if (!connector) throw new Error(`未知远程工具: ${name}`);
+    return connector.callTool(name, args);
+  }
+}
+
+export const mcpManager = new MCPManager();


### PR DESCRIPTION
## Summary
- add MCPConnector and manager to handle remote Model Context Protocol tools
- expose remote tools via getToolDefinitions and dispatch through ToolExecutor
- provide /api/mcp endpoint to register and list remote MCP services

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unknown options useEslintrc, extensions, resolvePluginsRelativeTo, rulePaths, ignorePath, reportUnusedDisableDirectives)*
- `npm run build` *(fails: Module not found: Can't resolve 'mcp')*

------
https://chatgpt.com/codex/tasks/task_e_689c3f50cda0832c8627e9d2fc5b646e